### PR TITLE
[Counter] Add the counter for TextFieldAddonsUIView

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,11 @@ let package = Package(
            /*version*/ "0.0.1"..."999.999.999"
        ),
        .package(
+           url: "https://github.com/adevinta/spark-ios-component-text-input.git",
+           // path: "../spark-ios-component-text-input"
+           /*version*/ "0.0.1"..."999.999.999"
+       ),
+       .package(
            url: "https://github.com/adevinta/spark-ios-theming.git",
            // path: "../spark-ios-theming"
            /*version*/ "0.0.1"..."999.999.999"
@@ -38,6 +43,10 @@ let package = Package(
                 .product(
                     name: "SparkCommon",
                     package: "spark-ios-common"
+                ),
+                .product(
+                    name: "SparkTextInput",
+                    package: "spark-ios-component-text-input"
                 ),
                 .product(
                     name: "SparkTheming",

--- a/Sources/Core/View/UIKit/FormFieldUIView.swift
+++ b/Sources/Core/View/UIKit/FormFieldUIView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import UIKit
 @_spi(SI_SPI) import SparkCommon
 import SparkTheming
+import SparkTextInput
 
 // TODO: compression resistance
 
@@ -402,6 +403,18 @@ public final class FormFieldUIView<Component: UIView>: UIView {
 // MARK: - Public Extension
 
 public extension FormFieldUIView where Component: UITextInput {
+
+    // MARK: - Public Setter
+
+    /// Display a counter value (X/Y) in the secondary helper label with a text and the limit.
+    /// - parameter text: the text where the characters must be counted.
+    /// - parameter limit: the counter limit. If the value is nil, the counter is not displayed.
+    func setCounter(on text: String?, limit: Int?) {
+        self.viewModel.setCounter(text: text, limit: limit)
+    }
+}
+
+public extension FormFieldUIView where Component: TextFieldAddonsUIView {
 
     // MARK: - Public Setter
 


### PR DESCRIPTION
Right now the TextFieldAddonsUIView (inherits from UIControl) doesn't have access to the ```setCounter``` function.
This PR fixes the problem